### PR TITLE
Adding SHEBANG, to make it possible to use the script without '-> python <- <script.py>'

### DIFF
--- a/awsgen.py
+++ b/awsgen.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 # ---------------------------
 # -- by m4ll0k --
 # -- github.com/m4ll0k --

--- a/bufferover.py
+++ b/bufferover.py
@@ -1,8 +1,8 @@
+#!/usr/bin/python
 # github.com/m4ll0k (@m4ll0k2) 
 # Bug Bounty Toolz - bufferover.py
 # bufferover.py - https://tls.bufferover.run/dns?q=<site>
 
-#!/usr/bin/python
 
 import sys
 import requests

--- a/bufferover.py
+++ b/bufferover.py
@@ -2,6 +2,7 @@
 # Bug Bounty Toolz - bufferover.py
 # bufferover.py - https://tls.bufferover.run/dns?q=<site>
 
+#!/usr/bin/python
 
 import sys
 import requests

--- a/bugmenot.py
+++ b/bugmenot.py
@@ -1,6 +1,6 @@
 # m4ll0k - github.com/m4ll0k
 # Get shared credentials for your bug bounty targets or for anything else
-
+#!/usr/bin/python
 
 import requests 
 import sys 

--- a/bugmenot.py
+++ b/bugmenot.py
@@ -1,6 +1,7 @@
+#!/usr/bin/python
+
 # m4ll0k - github.com/m4ll0k
 # Get shared credentials for your bug bounty targets or for anything else
-#!/usr/bin/python
 
 import requests 
 import sys 

--- a/csp-host-checker.py
+++ b/csp-host-checker.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 # by m4ll0k (@m4ll0k)
 # github.com/m4ll0k 
 # https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy

--- a/dynamicjs.py
+++ b/dynamicjs.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 #  by m4ll0k (@m4ll0k2)
 #  github.com/m4ll0k
 

--- a/favihash.py
+++ b/favihash.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 # m4ll0k - github.com/m4ll0k 
 # favihash - Subdomains enumeration via favicon.ico hashing - (beta v.) 
 # (@m4ll0k2)

--- a/find-all-links.py
+++ b/find-all-links.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 import requests
 import json
 import sys

--- a/getjswords.py
+++ b/getjswords.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 # by m4ll0k - github.com/m4ll0k 
 # (@m4ll0k2)
 

--- a/getrelationship.py
+++ b/getrelationship.py
@@ -1,3 +1,4 @@
+#!/usr/bin/python
 
 import requests
 from lxml import html

--- a/getsrc.py
+++ b/getsrc.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 # github.com/m4ll0k (@m4ll0k2) 
 # Bug Bounty Toolz - getSrc.py
 # getsrc.py - get script tag src (extract links)

--- a/jefst.py
+++ b/jefst.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 # github.com/m4ll0k (@m4ll0k2) 
 # Bug Bounty Toolz - jefst.py
 # jefst.py - json extractor from script tag

--- a/jldc.py
+++ b/jldc.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 # github.com/m4ll0k (@m4ll0k2) 
 # Bug Bounty Toolz - jldc.py
 # subdomain enum with jldc.me

--- a/jsbeautify.py
+++ b/jsbeautify.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 # by m4ll0k 
 # github.com/m4ll0k
 

--- a/phone-location.py
+++ b/phone-location.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 import requests
 import json
 import sys

--- a/ssrf.py
+++ b/ssrf.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 # m4ll0k - github.com/m4ll0k
 
 import requests

--- a/tojson.py
+++ b/tojson.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 import sys
 import json
 import argparse 

--- a/whoxy.py
+++ b/whoxy.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python
+
 # github.com/m4ll0k (@m4ll0k2) 
 # Bug Bounty Toolz - whoxy.py
 # whoxy.py - Whoxy Reverse Whois 


### PR DESCRIPTION
Even though It may sound like a nitpick, adding the shebang now provides the possibility to create symlinks for scripts to the directory inside $PATH environment variable. 
For example, without an added shebang, the interpreter cannot be resolved
![image](https://user-images.githubusercontent.com/32965886/97689804-682e0980-1a9c-11eb-90a5-98b7b4ab90b5.png)

With shebang added, the issue is solved
![image](https://user-images.githubusercontent.com/32965886/97689980-a88d8780-1a9c-11eb-9e20-d1a7b2d94479.png)

And with this, we can setup/copy the script into the directory in $PATH and use it flawlessly