### PR TITLE
Use ==/!= to compare constant literals (str, bytes, int, float, tuple)

### DIFF
--- a/whoxy.py
+++ b/whoxy.py
@@ -12,7 +12,7 @@ import json
 
 API_KEY = ""
 
-if API_KEY is "":
+if API_KEY == "":
 	sys.exit(print('Please set whoxy api_key!!'))
 
 def getWhoxyContent(keyword):


### PR DESCRIPTION
$ `flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics`
```
./BBTz/whoxy.py:15:4: F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
if API_KEY is "":
   ^
./BBTz/gctexposer.py:62:9: F821 undefined name 'sys'
        sys.exit(parser.print_help())
        ^
1     F632 use ==/!= to compare constant literals (str, bytes, int, float, tuple)
1     F821 undefined name 'sys'
2
```

$ `python3`
```
>>> "" == ""
True
>>> "" is ""
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
True
>>> API_KEY = "API_"
>>> API_KEY += "KEY"
>>> API_KEY == "API_KEY"
True
>>> API_KEY is "API_KEY"
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
False
```